### PR TITLE
fix: add token for release please action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
         id: release
         with:
           release-type: node
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - uses: actions/checkout@v4
       - name: tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Adds the RELEASE_PLEASE_TOKEN to the release workflow to enable 
authentication for the release process. This change ensures that 
the action can successfully trigger other actions.